### PR TITLE
Bind "q" key to quit-window

### DIFF
--- a/org-recoll.el
+++ b/org-recoll.el
@@ -100,6 +100,7 @@ deleting/editing parts of your research library."
     (define-key kmap (kbd "C-c n") 'org-recoll-next-page)
     (define-key kmap (kbd "C-c p") 'org-recoll-previous-page)
     (define-key kmap (kbd "C-c q") 'delete-window)
+    (define-key kmap (kbd "q") 'quit-window)
     kmap)
   "The keymap used for `org-recoll-mode'.")
 


### PR DESCRIPTION
In Emacs, buffers that are read-only (like info, dired, help, and many
others) have the key "q" bound to quit-window.  This is very handy and
org-recoll should do it too.