### PR TITLE
Add autoload cookies for public functions

### DIFF
--- a/org-recoll.el
+++ b/org-recoll.el
@@ -309,6 +309,7 @@ If PAGING is t this indicates that the function is being called to page through 
 ;;
 
 
+;;;###autoload
 (defun org-recoll-update-index ()
   "Invoke the recoll index update command string specified in ORG-RECOLL-INDEX-INVOCATION."
   (interactive)
@@ -339,6 +340,7 @@ If SQUERY is passed offer it as a default."
     " " 'minibuffer-complete-word)
   squery)
 
+;;;###autoload
 (defun org-recoll-search (&optional query)
   "Prompt for a QUERY and search."
   (interactive)


### PR DESCRIPTION
Autoload cookies are added for functions org-recoll-update-index and
org-recoll-search.  This is very handy when installing the package through
el-get.